### PR TITLE
disable profanity filter by default and add config

### DIFF
--- a/ovos_stt_plugin_azure/__init__.py
+++ b/ovos_stt_plugin_azure/__init__.py
@@ -7,6 +7,7 @@ class OVOSAzureSTT(STT):
         super().__init__(config)
         self.key = self.config.get("key")
         self.region = self.config.get("region", "westeurope")
+        self.profanity = self.config.get("profanity", "raw")
 
     def execute(self, audio, language=None):
         lang = language or self.lang
@@ -17,7 +18,7 @@ class OVOSAzureSTT(STT):
         url = f"https://{self.region}.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1"
         response = requests.request("POST", url, headers=headers,
                                     data=audio.get_wav_data(),
-                                    params={"language": lang}).json()
+                                    params={"language": lang, "profanity": self.profanity}).json()
         return response["DisplayText"]
 
 

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,16 @@ pip install ovos-stt-plugin-azure
 ```json
   "stt": {
     "module": "ovos-stt-plugin-azure",
-    "ovos-stt-plugin-azure": {"key": "xxx", "region": "westeurope"}
- }
+    "ovos-stt-plugin-azure": {
+      "key": "xxx",
+      "region": "westeurope",
+      "profanity": "raw"
+    }
+  }
 ```
+
+`key` - key for Azure AI services API
+
+`region`: location/region for your Azure speech service
+
+`profanity`: profanity filter setting, possible values are `raw`, `masked`, or `removed`


### PR DESCRIPTION
By default Azure has a list of words it masks with asterisks like `*****`. This change disables that by default, but adds a config to override it if desired.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an option to configure profanity filtering for speech recognition, allowing control over how speech content is processed.

- **Documentation**
  - Updated configuration guidelines to include instructions for setting up the new profanity filter, along with its default value and available options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->